### PR TITLE
style: quick wins to make styling more responsive

### DIFF
--- a/src/components/about/aboutUs.scss
+++ b/src/components/about/aboutUs.scss
@@ -1,10 +1,7 @@
 .about-us {
  background-color: #eee;
  margin: auto;
- width: 1000px;
- height: 400px;
  > h1 {
-   text-align: center;
    color: #529AED;
  }
  .people {

--- a/src/components/footer.css
+++ b/src/components/footer.css
@@ -2,9 +2,6 @@
     background: #529AED;
     font-size: 13px;
     padding-top: 1.5rem;
-    height: auto;
-    position: absolute;
-    bottom: 0;
     width: 100%;
     text-align: center;
     color: #FFFFFF;

--- a/src/components/header.css
+++ b/src/components/header.css
@@ -1,6 +1,5 @@
 .header {
   width: 100%;
-  height: 600px;
   background-color: #C0DAE9;
   display: flex;
   flex-flow: column wrap;
@@ -8,8 +7,12 @@
   padding: 10px;
 }
 
+.title-line {
+  text-align: center;
+  padding-bottom: 25px;
+}
+
 .title {
-  width: 597px;
   font-family: Lobster, cursive;
   font-size: 110px;
   font-weight: normal;
@@ -18,7 +21,11 @@
   line-height: 137px;
   text-decoration: none;
   margin-top: 25px;
-  margin-left: 320px;
+}
+
+.subtitle-line {
+  display: flex;
+  flex-flow: row wrap;
 }
 
 .box-text {
@@ -29,16 +36,27 @@
   text-decoration-line: underline;
   line-height: 56px;
   color: #16162C;
-  width: 580px;
   padding-top: 26px;
   padding-bottom: 20.5px;
   padding-left: 53px;
 }
 
+.box-text {
+  width: 80vw;
+}
+
 .box-container {
   background: #F9F7FA;
   width: 424px;
-  height: 222px;
   margin-bottom: 83px;
-  margin-left: 82px;
+}
+
+@media all and (min-width: 768px) {
+  .box-container {
+    margin-left: 82px;
+  }
+}
+
+#laptop {
+   padding-left: 149px;
 }

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -1,32 +1,36 @@
-import React from 'react'
-import { Link } from 'gatsby'
-import Navbar from '../components/navbar'
+import React from "react";
+import { Link } from "gatsby";
+import Navbar from "../components/navbar";
+import triangles from '../images/triangles.svg'
+import laptop from "../images/laptop.svg";
+import "./header.css";
+import "../components/navbar.css";
 
-
-import './header.css'
-import '../components/navbar.css'
-
-
-const Header = ({ subTitle, showTitle=false }) => {
-  if (showTitle){
+const Header = ({ subTitle, showTitle = false }) => {
+  if (showTitle) {
     return (
       <div className="header">
-        <div>
+        <div className="title-line">
+          <img id="triangles" src={triangles} />
           <h1 className="title">Polyglot Devs</h1>
         </div>
+
+        <div class="subtitle-line">
           <div className="box-container">
-            <h2 className="box-text">{subTitle}</h2>
+            <h2 className="box-text">{subTitle.split('\n').map((item, i) => <div key={i}>{item}</div>)}</h2>
           </div>
+          <img id="laptop" src={laptop} />
+        </div>
       </div>
-      )
+    );
   }
   return (
     <div className="header">
       <div className="box-container">
-        <h2 className="box-text">{subTitle}</h2>
+          <h2 className="box-text">{subTitle.split('\n').map((item, i) => <div key={i}>{item}</div>)}</h2>
       </div>
     </div>
-    )
-}
+  );
+};
 
-export default Header
+export default Header;

--- a/src/components/layout.css
+++ b/src/components/layout.css
@@ -188,19 +188,6 @@ textarea {
 
 }
 
-
-img {
-  max-width: 100%;
-  margin-left: 0;
-  margin-right: 0;
-  margin-top: 0;
-  padding-bottom: 0;
-  padding-left: 0;
-  padding-right: 0;
-  padding-top: 0;
-  margin-bottom: 1.45rem;
-}
-
 h2 {
   margin-left: 0;
   margin-right: 0;

--- a/src/images/triangles.svg
+++ b/src/images/triangles.svg
@@ -1,4 +1,4 @@
-<svg width="407" height="64" viewBox="0 0 47 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg width="47" height="64" viewBox="0 0 47 64" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path d="M30 1L16.5 15L45 35.5L30 1Z" fill="#FBE885"/>
 <path d="M1 28.5L45 47.5V56L1 62.5V28.5Z" fill="#FBE885"/>
 <path d="M30 1L16.5 15L45 35.5L30 1Z" stroke="#529AED"/>

--- a/src/pages/about.css
+++ b/src/pages/about.css
@@ -1,4 +1,9 @@
 .about-container {
-    height: 600px;
     width: 100%;
+}
+
+@media all and (min-width: 768px) {
+    .about-container {
+        padding: 59px;
+    }
 }

--- a/src/pages/contact.css
+++ b/src/pages/contact.css
@@ -36,11 +36,10 @@
     display: flex;
     flex-flow: row wrap;
     justify-content: space-around;
-    height: 1060px;
 }
 
 .signup {
-    flex: 0 0 400px;
+    flex: 1;
     padding: 100px 10px 50px 10px;
 }
 
@@ -92,8 +91,7 @@
 }
 
 .contact-container {
-    flex: 0 0 408px;
-    height: 630px;
+    flex: 1;
     background: #F9F7FA;
     margin-top: 60px;
     padding-top: 40px;

--- a/src/pages/contact.js
+++ b/src/pages/contact.js
@@ -14,7 +14,7 @@ const ContactPage = () => (
   <div>
   <div className="wrapper">
   <Navbar />
-  <Header subTitle="Join us or get in touch to learn more" />
+  <Header subTitle={"Join us or get in touch \nto learn more"} />
   </div>
 
   <Layout>

--- a/src/pages/index.css
+++ b/src/pages/index.css
@@ -74,10 +74,6 @@
   padding-right: 10px;
 }
 
-#triangles {
-  transform: translate(90px, 140px);
-}
-
-#laptop {
-  transform: translate(650px, -300px);
+.title {
+  display: inline;
 }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -5,8 +5,6 @@ import Header from '../components/header'
 import Layout from '../components/layout'
 import Image from '../components/image'
 
-import triangles from '../images/triangles.svg'
-import laptop from '../images/laptop.svg'
 
 import './index.css'
 import '../components/navbar.css'
@@ -18,9 +16,7 @@ const IndexPage = () => (
   <div>
     <div className="wrapper">
       <Navbar />
-      <img id="triangles" src={triangles} />
-      <Header subTitle="Monthly coding meetup in London" showTitle={true} />
-      <img id="laptop" src={laptop} />
+      <Header subTitle={"Monthly coding meetup \nin London"} showTitle={true} />
     </div>
   
   <Layout>

--- a/src/pages/partners.css
+++ b/src/pages/partners.css
@@ -51,7 +51,6 @@
 
 .partners-section {
    flex: 0 0 990px;
-   height: 300px;
    background: #F9F7FA;
    margin-bottom: 24px;
 }


### PR DESCRIPTION
Styling to make the marketing site more responsive.

Some quick wins to make it more responsive so we can link to it from Sharespots.

Much more work needed later to match all the designs.

Related to trello tickets 
https://trello.com/c/FTxXfSow/15-make-the-home-page-responsive-as-per-wireframes-it-needs-to-look-the-same-as-wireframes-on-mobile-desktop
https://trello.com/c/DF6FmFU2/6-get-the-page-title-in-the-right-font-looking-good-across-breakpoints